### PR TITLE
CI: Remove code style and use pre-commit.ci

### DIFF
--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -118,19 +118,13 @@ jobs:
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
           extra-targets: 'freeze'
 
-  code-style:
-    name: "Code style"
+  check-actions:
+    name: "Check GitHub Actions security"
     runs-on: ubuntu-latest
     permissions:
       contents: read
     needs: vulnerabilities
     steps:
-
-      - uses: ansys/actions/code-style@36cd86710c966963f4dcec56a9670171618cf76a # v10.2.4
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          use-python-cache: false
-
       - uses: ansys/actions/check-actions-security@36cd86710c966963f4dcec56a9670171618cf76a # v10.2.4
         with:
           generate-summary: true
@@ -167,7 +161,7 @@ jobs:
   wheelhouse:
     name: "Wheelhouse ${{ matrix.os }} / ${{ matrix.python}} "
     runs-on: ${{ matrix.os }}
-    needs: code-style
+    needs: check-actions
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -50,19 +50,13 @@ jobs:
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
           extra-targets: 'freeze'
 
-  code-style:
-    name: "Code style"
+  check-actions:
+    name: "Check GitHub Actions security"
     runs-on: ubuntu-latest
     permissions:
       contents: read
     needs: vulnerabilities
     steps:
-
-      - uses: ansys/actions/code-style@36cd86710c966963f4dcec56a9670171618cf76a # v10.2.4
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          use-python-cache: false
-
       - uses: ansys/actions/check-actions-security@36cd86710c966963f4dcec56a9670171618cf76a # v10.2.4
         with:
           generate-summary: true
@@ -99,7 +93,7 @@ jobs:
   wheelhouse:
     name: "Wheelhouse ${{ matrix.os }} / ${{ matrix.python}} "
     runs-on: ${{ matrix.os }}
-    needs: code-style
+    needs: check-actions
     permissions:
       contents: read
     strategy:

--- a/doc/changelog.d/32.maintenance.md
+++ b/doc/changelog.d/32.maintenance.md
@@ -1,0 +1,1 @@
+Remove code style and use pre-commit.ci


### PR DESCRIPTION
## Description
Remove code-style action and leverage [pre-commit.ci](https://pre-commit.ci/) instead.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).