### PR TITLE
FIX: Update project dependencies and perform related adjustments to fix broken 3D ``pyvista`` plots in doc

### DIFF
--- a/.github/workflows/ci_cd_night.yml
+++ b/.github/workflows/ci_cd_night.yml
@@ -321,7 +321,6 @@ jobs:
       - name: Test API
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m radar_toolkit_api
 
@@ -329,28 +328,24 @@ jobs:
       - name: Test Domain Transform API
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m domain_transforms
 
       - name: Test REST API
         timeout-minutes: 5
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m rest_api_toolkit
 
       - name: Test Visualization
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m radar_visualization
 
       - name: Test Run Toolkit utils
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m run_utils
 

--- a/.github/workflows/ci_cd_pr.yml
+++ b/.github/workflows/ci_cd_pr.yml
@@ -450,7 +450,6 @@ jobs:
       - name: Test API
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m radar_toolkit_api
 
@@ -458,28 +457,24 @@ jobs:
       - name: Test Domain Transform API
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m domain_transforms
 
       - name: Test REST API
         timeout-minutes: 5
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m rest_api_toolkit
 
       - name: Test Visualization
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m radar_visualization
 
       - name: Test Run Toolkit utils
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m run_utils
 

--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -382,7 +382,6 @@ jobs:
       - name: Test API
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m radar_toolkit_api
 
@@ -390,28 +389,24 @@ jobs:
       - name: Test Domain Transform API
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m domain_transforms
 
       - name: Test REST API
         timeout-minutes: 5
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m rest_api_toolkit
 
       - name: Test Visualization
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m radar_visualization
 
       - name: Test Run Toolkit utils
         timeout-minutes: 15
         run: |
-          export LD_LIBRARY_PATH=${ANSYSEM_ROOT252}/common/mono/Linux64/lib64:$LD_LIBRARY_PATH
           source .venv_linux/bin/activate
           pytest -v -m run_utils
 

--- a/doc/changelog.d/34.fixed.md
+++ b/doc/changelog.d/34.fixed.md
@@ -1,0 +1,1 @@
+Update project dependencies and perform related adjustments to fix broken 3D \`\`pyvista\`\` plots in doc

--- a/doc/source/examples/get_rcs_IE.py
+++ b/doc/source/examples/get_rcs_IE.py
@@ -38,7 +38,7 @@ from ansys.aedt.toolkits.radar_explorer.rcs_visualization import MonostaticRCSPl
 #
 # Set AEDT version.
 
-aedt_version = "2025.1"
+aedt_version = "2025.2"
 
 # ## Set non-graphical mode
 #

--- a/doc/source/examples/import_cad.py
+++ b/doc/source/examples/import_cad.py
@@ -36,7 +36,7 @@ from ansys.aedt.toolkits.radar_explorer.rcs_visualization import MonostaticRCSPl
 
 # ## Set AEDT version
 
-aedt_version = "2025.1"
+aedt_version = "2025.2"
 
 # ## Set non-graphical mode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "pyaedt==1.0.0rc1",
     "ansys-aedt-toolkits-common[all]"
 ]
 
@@ -32,7 +33,8 @@ tests = [
     "ansys-aedt-toolkits-common[tests]"
 ]
 doc = [
-    "ansys-aedt-toolkits-common[doc]"
+    "ansys-aedt-toolkits-common[doc]",
+    "pyvista[jupyter]"
 ]
 freeze = [
     "pyinstaller"

--- a/src/ansys/aedt/toolkits/radar_explorer/rcs_visualization.py
+++ b/src/ansys/aedt/toolkits/radar_explorer/rcs_visualization.py
@@ -92,7 +92,7 @@ class MonostaticRCSData(object):
     --------
     >>> from ansys.aedt.core import Hfss
     >>> from ansys.aedt.toolkits.radar_explorer.rcs_visualization import MonostaticRCSData
-    >>> app = Hfss(version="2025.1", design="Antenna")
+    >>> app = Hfss(version="2025.2", design="Antenna")
     >>> data = app.get_rcs_data()
     >>> metadata_file = data.metadata_file
     >>> app.release_desktop()
@@ -905,7 +905,7 @@ class MonostaticRCSPlotter(object):
     >>> from ansys.aedt.core import Hfss
     >>> from ansys.aedt.toolkits.radar_explorer.rcs_visualization import MonostaticRCSData
     >>> from ansys.aedt.toolkits.radar_explorer.rcs_visualization import MonostaticRCSPlotter
-    >>> app = Hfss(version="2025.1", design="Antenna")
+    >>> app = Hfss(version="2025.2", design="Antenna")
     >>> data = app.get_rcs_data()
     >>> metadata_file = data.metadata_file
     >>> app.release_desktop()

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -45,8 +45,9 @@ from pathlib import Path
 import shutil
 from typing import Optional
 
-from ansys.aedt.core.generic.settings import settings
 import pytest
+
+from ansys.aedt.core.generic.settings import settings
 
 DEFAULT_CONFIG = {"desktop_version": "2025.2", "non_graphical": True, "use_grpc": True, "debug": False}
 LOCAL_CFG_FILE = "local_config.json"

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -45,7 +45,7 @@ from pathlib import Path
 import shutil
 from typing import Optional
 
-from pyaedt import settings
+from ansys.aedt.core.generic.settings import settings
 import pytest
 
 DEFAULT_CONFIG = {"desktop_version": "2025.2", "non_graphical": True, "use_grpc": True, "debug": False}

--- a/tests/backend/tests_toolkit_api/conftest.py
+++ b/tests/backend/tests_toolkit_api/conftest.py
@@ -29,7 +29,7 @@ The default configuration can be changed by placing a file called local_config.j
 An example of the contents of local_config.json:
 
 {
-  "desktop_version": "2025.1",
+  "desktop_version": "2025.2",
   "non_graphical": false,
   "use_grpc": true
 }


### PR DESCRIPTION
This PR updates the project dependencies in order to fix the ``pyvista`` 3D plots that are currently broken in the documentation.
In particular the project is now specifically based on:
* ``1.0.0rc1`` version of ``pyaedt`` in order to leverage the latest versions of ``pyvista`` and ``vtk`` packages which were made available for ``pyaedt`` in https://github.com/ansys/pyaedt/pull/7295,
* ``pyvista[jupyter]`` which is recommended in https://github.com/pyvista/pyvista/issues/5848 to render ``pyvista`` 3D plots in Jupyter.

A few other changes are introduced, in particular:
* The ``export LD_LIBRARY_PATH`` command used in linux tests is removed for all CI workflows as performed in https://github.com/ansys/pyaedt/pull/6958,
* An old import from the deprecated alias ``pyaedt`` is removed in a ``conftest.py`` file,
* Version of AEDT is bumped from 2025.1 to 2025.2 in all scripts.

Note: A revised implementation of the example scripts is being developed in #29 with the aim of presenting 3D ``pyvista`` plots using a ``sphinx-gallery``, as performed for instance on [this page](https://visualization-interface.tools.docs.pyansys.com/version/stable/examples/00-basic-pyvista-examples/clipping_plane.html#sphx-glr-examples-00-basic-pyvista-examples-clipping-plane-py) of the ``visualization-interface`` project. 