### PR TITLE
CI: Use correct env variable when publishing

### DIFF
--- a/.github/workflows/ci_cd_release.yml
+++ b/.github/workflows/ci_cd_release.yml
@@ -479,7 +479,7 @@ jobs:
         with:
           repository-url: "https://upload.pypi.org/legacy/"
           print-hash: true
-          packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+          packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
           skip-existing: false
 
   doc-deploy-stable:

--- a/doc/changelog.d/50.maintenance.md
+++ b/doc/changelog.d/50.maintenance.md
@@ -1,0 +1,1 @@
+Use correct env variable when publishing


### PR DESCRIPTION
## Description
As title says. There is a typo with the environment variable used to fetch artifacts.

## Issue linked
None

## Checklist
- [ ] I have tested my changes locally.
- [ ] I have added necessary documentation or updated existing documentation.
- [ ] I have followed the coding style guidelines of this project.
- [ ] I have added appropriate tests (unit, integration, system).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have linked the issue or issues that are solved by the PR if any.
- [ ] I have agreed with the Contributor License Agreement ([CLA](https://developer.ansys.com/form/cla-acceptance)).